### PR TITLE
fix: raise exception on status code gt 400

### DIFF
--- a/srcomapi/srcomapi.py
+++ b/srcomapi/srcomapi.py
@@ -64,7 +64,7 @@ class SpeedrunCom(object):
                     raise APIRequestException((response.status_code, responses[response.status_code], uri[len(API_URL):]), response)
         else:
             response = requests.get(uri, **kwargs)
-            if response.status_code == 404:
+            if response.status_code > 400:
                 raise APIRequestException((response.status_code, responses[response.status_code], uri[len(API_URL):]), response)
             data = response.json()["data"]
             try:


### PR DESCRIPTION
As mentioned on this [issue](https://github.com/blha303/srcomapi/issues/14), the package does not raise exceptions on status code 420. Furthermore, I was experiencing issues while tryin to execute the following code:

```py
mc = sr_api.search(srcomapi.datatypes.Game, {"name": "Minecraft: Java Edition"})[0]
cat = mc.categories[0].records[0].category
board = sdt.Leaderboard(sr_api, data = sr_api.get(f"leaderboards/{mc.id}/category/{cat.id}?embed=players"))
print(len(board.runs))
```

Result was a `JSONDecodeError`, which was being thrown because underlying request was receiving status code 408, and code was setup to throw exception only on status_code 404.

With this oneliner, it'd throw exception on status_code > 404